### PR TITLE
nginx-fpm default config typo fix

### DIFF
--- a/sites/default
+++ b/sites/default
@@ -17,7 +17,7 @@ server {
   }
 
   location ~ \.php$ {
-    try_files     $uri=404;
+    try_files     $uri =404;
     include       fastcgi_params;
     fastcgi_index index.php;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
I couldn't run nginx-php-fpm container because there is typo in nginx default config file. Just one missed space but it's crashing nginx on start